### PR TITLE
Update docker images for VueJS

### DIFF
--- a/Frontend/VueJS/web.Dockerfile
+++ b/Frontend/VueJS/web.Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM node:9.11.1-alpine as build-stage
+FROM node:lts-alpine as build-stage
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
@@ -7,9 +7,10 @@ COPY . .
 RUN npm run build
 
 # production stage
-FROM nginx:1.13.12-alpine as production-stage
+FROM nginx:stable-alpine as production-stage
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 RUN chown -R nginx:nginx /usr/share/nginx/html/
 # Uncomment the following line for using a custom nginx template, remember the "nginx.conf" file
 #COPY nginx.conf /etc/nginx/conf.d/default.conf
-CMD ["nginx", "-c", "./nginx.conf", "-g", "daemon off;"]
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
I updated the Dockerfile for VueJS to (always) use the latest versions of `node` and `nginx`. In the first place I wanted to suggest the new versions, on the other hand, I thought using `lts` and `stable` would be good suggestions.

And even when using `nginx.conf` I think that `-c ./nginx.conf` is not necessary, because the `COPY` command already puts the file in the right place.